### PR TITLE
Template null background support and migration

### DIFF
--- a/bin/aiconvert/aiconvert.js
+++ b/bin/aiconvert/aiconvert.js
@@ -25,11 +25,12 @@ import { v4 as uuidv4 } from 'uuid';
  * Internal dependencies
  */
 import { writeFileAsync } from '../utils/writeFileAsync';
+import { migrate } from '../utils/migration';
 import { getStoryMarkup } from './storyconvert';
 
 export function getStoryJson(data, template) {
   const { pages, ...dataOptions } = data;
-  const { pages: templatePages, layouts = {}, ...options } = template;
+  const { pages: templatePages, layouts = {}, ...options } = migrate(template);
 
   for (const [key, value] of Object.entries(dataOptions)) {
     options[key] = options[key] ?? value;

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -19,6 +19,8 @@
  */
 import readline from 'readline';
 
+const DATA_VERSION = 21;
+
 export default function generateTemplate() {
   const lines = [];
 
@@ -26,6 +28,10 @@ export default function generateTemplate() {
     input: process.stdin,
     output: process.stdout,
   });
+
+  process.stderr.write(
+    `Please paste v${DATA_VERSION} story exported from editor:\n`
+  );
 
   rl.on('line', (line) => {
     if (line) {
@@ -75,7 +81,7 @@ export default function generateTemplate() {
     }
 
     const template = {
-      version: 21,
+      version: DATA_VERSION,
       templateVersion: 1,
       layouts: {
         COVER: 0,

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -19,7 +19,12 @@
  */
 import readline from 'readline';
 
-const DATA_VERSION = 21;
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_VERSION } from './migration';
+
+const STORY_DATA_VERSION = 21;
 
 export default function generateTemplate() {
   const lines = [];
@@ -30,7 +35,7 @@ export default function generateTemplate() {
   });
 
   process.stderr.write(
-    `Please paste v${DATA_VERSION} story exported from editor:\n`
+    `Please paste v${STORY_DATA_VERSION} story exported from editor:\n`
   );
 
   rl.on('line', (line) => {
@@ -81,8 +86,8 @@ export default function generateTemplate() {
     }
 
     const template = {
-      version: DATA_VERSION,
-      templateVersion: 1,
+      version: STORY_DATA_VERSION,
+      templateVersion: TEMPLATE_VERSION,
       layouts: {
         COVER: 0,
         NORMAL: 1,

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -22,16 +22,15 @@ import readline from 'readline';
 /**
  * Internal dependencies
  */
-import { TEMPLATE_VERSION } from './migration';
+import { TEMPLATE_VERSION } from './migration/migrate.js';
 
 const STORY_DATA_VERSION = 21;
 
-export default function generateTemplate() {
+async function loadJsonFromStdIn() {
   const lines = [];
 
   const rl = readline.createInterface({
     input: process.stdin,
-    output: process.stdout,
   });
 
   process.stderr.write(
@@ -46,59 +45,68 @@ export default function generateTemplate() {
     }
   });
 
-  rl.on('close', () => {
-    const { pages } = JSON.parse(lines.join(''));
-    for (const page of pages) {
-      page.elements.forEach((element, i) => {
-        if (!element.isBackground) {
-          return;
-        }
+  await new Promise((resolve) => rl.on('close', resolve));
 
-        Object.assign(element, {
+  return JSON.parse(lines.join(''));
+}
+
+export default async function generateTemplate(exportedStory) {
+  if (!exportedStory) {
+    exportedStory = await loadJsonFromStdIn();
+  }
+
+  const { pages } = exportedStory;
+  for (const page of pages) {
+    page.elements.forEach((element, i) => {
+      if (!element.isBackground) {
+        return;
+      }
+
+      Object.assign(element, {
+        type: '{{background.type}}',
+        scale: '{{background.scale * 100}}',
+        focalX: '{{focal_x / background.width * 100}}',
+        focalY: '{{focal_y / background.height * 100}}',
+        resource: {
           type: '{{background.type}}',
-          scale: '{{background.scale * 100}}',
-          focalX: '{{focal_x / background.width * 100}}',
-          focalY: '{{focal_y / background.height * 100}}',
-          resource: {
-            type: '{{background.type}}',
-            mimeType: '{{background.mime}}',
-            src: '{{background.file}}',
-            width: '{{background.width}}',
-            height: '{{background.height}}',
-            poster: '{{background.thumbnail}}',
-            length: '{{background.duration}}',
-            title: '{{background.title}}',
-            alt: '{{background.description}}',
-            local: false,
-            sizes: "{{background.type === 'video' ? [] : {} }}",
-          },
-          loop: element.loop ?? false,
-          autoPlay: element.autoPlay ?? true,
-          controls: element.controls ?? false,
-        });
-
-        page.elements[i] = [
-          {
-            '{{#if background}}': element,
-          },
-        ];
+          mimeType: '{{background.mime}}',
+          src: '{{background.file}}',
+          width: '{{background.width}}',
+          height: '{{background.height}}',
+          poster: '{{background.thumbnail}}',
+          length: '{{background.duration}}',
+          title: '{{background.title}}',
+          alt: '{{background.description}}',
+          local: false,
+          sizes: "{{background.type === 'video' ? [] : {} }}",
+        },
+        loop: element.loop ?? false,
+        autoPlay: element.autoPlay ?? true,
+        controls: element.controls ?? false,
       });
-    }
 
-    const template = {
-      version: STORY_DATA_VERSION,
-      templateVersion: TEMPLATE_VERSION,
-      layouts: {
-        COVER: 0,
-        NORMAL: 1,
-        FOCUS: 2,
-        QUOTE: 3,
-      },
-      pages,
-    };
+      page.elements[i] = [
+        {
+          '{{#if background}}': element,
+        },
+      ];
+    });
+  }
 
-    const output = JSON.stringify(template, null, 2);
+  const template = {
+    version: STORY_DATA_VERSION,
+    templateVersion: TEMPLATE_VERSION,
+    layouts: {
+      COVER: 0,
+      NORMAL: 1,
+      FOCUS: 2,
+      QUOTE: 3,
+    },
+    pages,
+  };
 
-    process.stdout.write(output);
-  });
+  const output = JSON.stringify(template, null, 2);
+  process.stdout.write(output);
+
+  return template;
 }

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -75,6 +75,8 @@ export default function generateTemplate() {
     }
 
     const template = {
+      version: 21,
+      templateVersion: 1,
       layouts: {
         COVER: 0,
         NORMAL: 1,
@@ -82,7 +84,6 @@ export default function generateTemplate() {
         QUOTE: 3,
       },
       pages,
-      version: 21,
     };
 
     const output = JSON.stringify(template, null, 2);

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -38,32 +38,40 @@ export default function generateTemplate() {
   rl.on('close', () => {
     const { pages } = JSON.parse(lines.join(''));
     for (const page of pages) {
-      for (const element of page.elements) {
-        if (element.isBackground) {
-          Object.assign(element, {
-            type: '{{background.type}}',
-            scale: '{{background.scale * 100}}',
-            focalX: '{{focal_x / background.width * 100}}',
-            focalY: '{{focal_y / background.height * 100}}',
-            resource: {
-              type: '{{background.type}}',
-              mimeType: '{{background.mime}}',
-              src: '{{background.file}}',
-              width: '{{background.width}}',
-              height: '{{background.height}}',
-              poster: '{{background.thumbnail}}',
-              length: '{{background.duration}}',
-              title: '{{background.title}}',
-              alt: '{{background.description}}',
-              local: false,
-              sizes: "{{background.type === 'video' ? [] : {} }}",
-            },
-            loop: element.loop ?? false,
-            autoPlay: element.autoPlay ?? true,
-            controls: element.controls ?? false,
-          });
+      page.elements.forEach((element, i) => {
+        if (!element.isBackground) {
+          return;
         }
-      }
+
+        Object.assign(element, {
+          type: '{{background.type}}',
+          scale: '{{background.scale * 100}}',
+          focalX: '{{focal_x / background.width * 100}}',
+          focalY: '{{focal_y / background.height * 100}}',
+          resource: {
+            type: '{{background.type}}',
+            mimeType: '{{background.mime}}',
+            src: '{{background.file}}',
+            width: '{{background.width}}',
+            height: '{{background.height}}',
+            poster: '{{background.thumbnail}}',
+            length: '{{background.duration}}',
+            title: '{{background.title}}',
+            alt: '{{background.description}}',
+            local: false,
+            sizes: "{{background.type === 'video' ? [] : {} }}",
+          },
+          loop: element.loop ?? false,
+          autoPlay: element.autoPlay ?? true,
+          controls: element.controls ?? false,
+        });
+
+        page.elements[i] = [
+          {
+            '{{#if background}}': element,
+          },
+        ];
+      });
     }
 
     const template = {

--- a/bin/utils/generateTemplate.js
+++ b/bin/utils/generateTemplate.js
@@ -74,6 +74,7 @@ export default function generateTemplate() {
         QUOTE: 3,
       },
       pages,
+      version: 21,
     };
 
     const output = JSON.stringify(template, null, 2);

--- a/bin/utils/migration/index.js
+++ b/bin/utils/migration/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { DATA_VERSION, migrate } from './migrate';

--- a/bin/utils/migration/index.js
+++ b/bin/utils/migration/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { TEMPLATE_VERSION, migrate } from './migrate';
+export { TEMPLATE_VERSION, migrate } from './migrate.js';

--- a/bin/utils/migration/index.js
+++ b/bin/utils/migration/index.js
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { DATA_VERSION, migrate } from './migrate';
+export { TEMPLATE_VERSION, migrate } from './migrate';

--- a/bin/utils/migration/migrate.js
+++ b/bin/utils/migration/migrate.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import backgroundConditionClause from './migrations/v0001_backgroundConditionClause';
+
+const MIGRATIONS = {
+  1: [backgroundConditionClause],
+};
+
+export const DATA_VERSION = Math.max.apply(
+  null,
+  Object.keys(MIGRATIONS).map(Number)
+);
+
+export function migrate(slottedTemplate) {
+  const version = slottedTemplate.templateVersion || 0;
+  let result = slottedTemplate;
+  for (let v = version; v < DATA_VERSION; v++) {
+    const migrations = MIGRATIONS[v + 1];
+    if (!migrations) {
+      continue;
+    }
+    for (let i = 0; i < migrations.length; i++) {
+      result = migrations[i](result);
+    }
+  }
+  return result;
+}
+
+export default migrate;

--- a/bin/utils/migration/migrate.js
+++ b/bin/utils/migration/migrate.js
@@ -23,7 +23,7 @@ const MIGRATIONS = {
   1: [backgroundConditionClause],
 };
 
-export const DATA_VERSION = Math.max.apply(
+export const TEMPLATE_VERSION = Math.max.apply(
   null,
   Object.keys(MIGRATIONS).map(Number)
 );
@@ -31,7 +31,7 @@ export const DATA_VERSION = Math.max.apply(
 export function migrate(slottedTemplate) {
   const version = slottedTemplate.templateVersion || 0;
   let result = slottedTemplate;
-  for (let v = version; v < DATA_VERSION; v++) {
+  for (let v = version; v < TEMPLATE_VERSION; v++) {
     const migrations = MIGRATIONS[v + 1];
     if (!migrations) {
       continue;

--- a/bin/utils/migration/migrate.js
+++ b/bin/utils/migration/migrate.js
@@ -17,7 +17,7 @@
 /**
  * Internal dependencies
  */
-import backgroundConditionClause from './migrations/v0001_backgroundConditionClause';
+import backgroundConditionClause from './migrations/v0001_backgroundConditionClause.js';
 
 const MIGRATIONS = {
   1: [backgroundConditionClause],

--- a/bin/utils/migration/migrations/v0001_backgroundConditionClause.js
+++ b/bin/utils/migration/migrations/v0001_backgroundConditionClause.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function backgroundConditionClause(template) {
+  for (const page of template.pages) {
+    page.elements.forEach((element, i) => {
+      if (!element.isBackground) {
+        return;
+      }
+
+      page.elements[i] = [
+        {
+          '{{#if background}}': element,
+        },
+      ];
+    });
+  }
+
+  template.version = 21;
+  return template;
+}
+
+export default backgroundConditionClause;

--- a/bin/utils/test/generateTemplate.js
+++ b/bin/utils/test/generateTemplate.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import generateTemplate from '../generateTemplate';
+
+describe('generateTemplate', () => {
+  it('returns a template with required properties', async () => {
+    const template = await generateTemplate({
+      pages: [],
+    });
+
+    expect(template).toHaveProperty(
+      'version',
+      'templateVersion',
+      'layouts',
+      'pages'
+    );
+  });
+
+  it('returns background template with condition clause', async () => {
+    const template = await generateTemplate({
+      pages: [
+        {
+          elements: [
+            {
+              isBackground: true,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(template.pages[0].elements[0]).toStrictEqual([
+      {
+        '{{#if background}}': expect.any(Object),
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
fix #33 
- Add storyData version on template
- Add templateVersion & template migrate
- Migrate template before convert
- Migrate storyData after convert
- **Caveat**: should only `generate-template` from the same version of story data, or converting may not work right.